### PR TITLE
Add attachment and document operations with handlers and API requests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,6 +38,76 @@
 				"$tsc"
 			],
 			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
+		},
+		{
+			"label": "build:tsc",
+			"type": "shell",
+			"command": "npm run build",
+			"isBackground": false,
+			"problemMatcher": [
+				"$tsc"
+			],
+			"group": "build"
 		}
 	]
 }

--- a/README.md
+++ b/README.md
@@ -149,6 +149,47 @@ The Dynamic resource allows you to work with any entity type in your EspoCRM sys
 }
 ```
 
+### Attachments & Documents
+
+You can upload files to EspoCRM as `Attachment` records and then create a `Document` that references the uploaded file. You can also download attachments to binary output in n8n.
+
+1) Upload an Attachment
+
+- Add an `EspoCRM` node
+- Resource: `Attachment`
+- Operation: `Upload`
+- Fields:
+  - `Binary Property`: name of the binary key on the incoming item (default `data`)
+  - `Related Type`: usually `Document` (but can be any entity supported by your instance)
+  - `Field`: usually `file` for Document’s File field
+  - `Role`: defaults to `Attachment` (other roles: Inline Attachment)
+- The node derives `name`, `type`, and `size` from the binary; you can override `name` and `type` in Additional Fields
+- Output contains the created Attachment `id`
+
+2) Create a Document linked to the uploaded file
+
+- Add a second `EspoCRM` node
+- Resource: `Document`
+- Operation: `Create`
+- Fields:
+  - `Name`: document name
+  - `File ID`: reference the Attachment `id` (from the previous step)
+  - Optional: `Publish Date` (date only is expected; we normalize inputs), `Status`, `File Name`, `Folder ID`, `Description`, `Assigned User ID`
+
+3) Download an Attachment
+
+- Add an `EspoCRM` node
+- Resource: `Attachment`
+- Operation: `Download`
+- Fields:
+  - `Attachment ID`: the Attachment record ID
+  - `Binary Property`: output key to store the file (default `data`)
+- Output: one item with `binary[Binary Property]` populated, including `fileName` and `mimeType`
+
+Notes:
+- EspoCRM may restrict allowed file types by extension/MIME. If you receive `403 Not allowed file type`, verify your instance settings and the file’s extension/MIME.
+- For attachment-multiple fields (e.g., `Note.attachments`), upload first, then create/update the parent entity with `attachmentsIds` including the returned attachment ID (remember to include existing IDs when updating to avoid unlinking).
+
 ## Resources
 
 - [EspoCRM API Documentation](https://docs.espocrm.com/development/api/)

--- a/nodes/EspoCRM/EspoCRM.node.ts
+++ b/nodes/EspoCRM/EspoCRM.node.ts
@@ -18,6 +18,8 @@ import { meetingOperations, meetingFields } from './operations/meeting/meeting.o
 import { taskOperations, taskFields } from './operations/task/task.operations';
 import { callOperations, callFields } from './operations/call/call.operations';
 import { opportunityOperations, opportunityFields } from './operations/opportunity/opportunity.operations';
+import { attachmentOperations, attachmentFields } from './operations/attachment/attachment.operations';
+import { documentOperations, documentFields } from './operations/document/document.operations';
 import { caseOperations, caseFields } from './operations/case/case.operations';
 
 // Import handler factory
@@ -98,6 +100,14 @@ export class EspoCRM implements INodeType {
 						name: 'Case',
 						value: 'case',
 					},
+					{
+						name: 'Attachment',
+						value: 'attachment',
+					},
+					{
+						name: 'Document',
+						value: 'document',
+					},
 				],
 				default: 'contact',
 			},
@@ -136,6 +146,10 @@ export class EspoCRM implements INodeType {
 			...opportunityFields,
 			...caseOperations,
 			...caseFields,
+			...attachmentOperations,
+			...attachmentFields,
+			...documentOperations,
+			...documentFields,
 			...dynamicOperations,
 			...dynamicFields,
 
@@ -540,6 +554,15 @@ export class EspoCRM implements INodeType {
 
 					// Execute the operation using the handler
 					let responseData: IDataObject | IDataObject[];
+
+
+
+					// Special-case: map attachment upload -> create
+					if (resource === 'attachment' && operation === 'upload') {
+						responseData = await handler.create.call(this, i);
+						returnData.push(responseData as IDataObject);
+						break;
+					}
 
 					switch (operation) {
 						case 'create':

--- a/nodes/EspoCRM/handlers/AttachmentHandler.ts
+++ b/nodes/EspoCRM/handlers/AttachmentHandler.ts
@@ -1,0 +1,103 @@
+import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
+import { EntityHandler } from './EntityHandler';
+import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
+
+export class AttachmentHandler implements EntityHandler {
+  async create(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    // This method will be used for "upload" operation mapped to create
+    const binaryPropertyName = this.getNodeParameter('binaryPropertyName', index) as string;
+  const item = this.getInputData()[index];
+    if (!item.binary || !item.binary[binaryPropertyName]) {
+      throw new NodeOperationError(this.getNode(), `No binary data property "${binaryPropertyName}" exists on item!`);
+    }
+    const binary = item.binary[binaryPropertyName];
+
+    const role = (this.getNodeParameter('role', index) as string) || 'Attachment';
+    const relatedType = (this.getNodeParameter('relatedType', index) as string) || 'Document';
+    const field = (this.getNodeParameter('field', index) as string) || 'file';
+    const additionalFields = this.getNodeParameter('additionalFields', index, {}) as IDataObject;
+
+    const nameFromBinary = binary.fileName || (additionalFields.name as string) || 'file';
+    // Try to use binary mime, fallback to guess by extension, then default
+    const guessMimeByExt = (fileName?: string): string | undefined => {
+      if (!fileName) return undefined;
+      const ext = fileName.split('.').pop()?.toLowerCase();
+      switch (ext) {
+        case 'pdf': return 'application/pdf';
+        case 'txt': return 'text/plain';
+        case 'csv': return 'text/csv';
+        case 'json': return 'application/json';
+        case 'jpg':
+        case 'jpeg': return 'image/jpeg';
+        case 'png': return 'image/png';
+        case 'gif': return 'image/gif';
+        case 'doc': return 'application/msword';
+        case 'docx': return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+        case 'xls': return 'application/vnd.ms-excel';
+        case 'xlsx': return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+        default: return undefined;
+      }
+    };
+    const typeFromBinary = binary.mimeType || (additionalFields.type as string) || guessMimeByExt(nameFromBinary) || 'application/octet-stream';
+    // Ensure size is a number; if not present, compute from base64 length
+    const sizeFromBinary = typeof binary.fileSize !== 'undefined'
+      ? Number(binary.fileSize)
+      : (typeof binary.data === 'string' ? Buffer.from(binary.data, 'base64').length : undefined);
+
+    // Compose data: URI
+  const dataUri = `data:${typeFromBinary};base64,${binary.data}`;
+
+    const body: IDataObject = {
+      role,
+      relatedType,
+      field,
+      name: nameFromBinary,
+      type: typeFromBinary,
+      file: dataUri,
+      ...additionalFields,
+    };
+    if (typeof sizeFromBinary === 'number' && !isNaN(sizeFromBinary)) {
+      body.size = sizeFromBinary;
+    }
+
+  const response = await espoApiRequest.call(this, 'POST', '/Attachment', body);
+    return response as IDataObject;
+  }
+
+  async get(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const id = this.getNodeParameter('attachmentId', index) as string;
+  const response = await espoApiRequest.call(this, 'GET', `/Attachment/${id}`);
+    return response as IDataObject;
+  }
+
+  async update(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+  // Read a parameter to avoid unused parameter warning
+  void this.getNodeParameter('attachmentId', index, '');
+  throw new NodeOperationError(this.getNode(), 'Update operation is not supported for Attachment');
+  }
+
+  async delete(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const id = this.getNodeParameter('attachmentId', index) as string;
+  await espoApiRequest.call(this, 'DELETE', `/Attachment/${id}`);
+    return { success: true, entityType: 'attachment', id } as IDataObject;
+  }
+
+  async getAll(this: IExecuteFunctions, index: number): Promise<IDataObject[]> {
+    // Not typically used for attachments but provide minimal implementation
+    const returnAll = this.getNodeParameter('returnAll', index, false) as boolean;
+    const qs: IDataObject = {};
+    if (returnAll) {
+  return await espoApiRequestAllItems.call(this, 'GET', '/Attachment', {}, qs);
+    } else {
+      const limit = this.getNodeParameter('limit', index, 50) as number;
+      qs.maxSize = limit;
+  const response = await espoApiRequest.call(this, 'GET', '/Attachment', {}, qs);
+      return response.list as IDataObject[];
+    }
+  }
+
+  // Custom: Download operation - not part of EntityHandler interface, so handled in node execute routing or via getAll mapping
+  async download(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    throw new NodeOperationError(this.getNode(), 'Attachment download is temporarily disabled');
+  }
+}

--- a/nodes/EspoCRM/handlers/DocumentHandler.ts
+++ b/nodes/EspoCRM/handlers/DocumentHandler.ts
@@ -1,0 +1,67 @@
+import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
+import { EntityHandler } from './EntityHandler';
+import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
+import { toEspoDate } from './Utils';
+
+export class DocumentHandler implements EntityHandler {
+  async create(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const entityData: IDataObject = {};
+    entityData.name = this.getNodeParameter('name', index) as string;
+    entityData.fileId = this.getNodeParameter('fileId', index) as string;
+    const publishDate = this.getNodeParameter('publishDate', index, '') as string;
+    if (publishDate) entityData.publishDate = toEspoDate(publishDate);
+
+    const additionalFields = this.getNodeParameter('additionalFields', index, {}) as IDataObject;
+    Object.assign(entityData, additionalFields);
+
+  const response = await espoApiRequest.call(this, 'POST', '/Document', entityData);
+    return response as IDataObject;
+  }
+
+  async get(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const id = this.getNodeParameter('documentId', index) as string;
+  const response = await espoApiRequest.call(this, 'GET', `/Document/${id}`);
+    return response as IDataObject;
+  }
+
+  async update(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const id = this.getNodeParameter('documentId', index) as string;
+    const updateFields = this.getNodeParameter('updateFields', index, {}) as IDataObject;
+    if (updateFields.publishDate) updateFields.publishDate = toEspoDate(updateFields.publishDate as string);
+  const response = await espoApiRequest.call(this, 'PATCH', `/Document/${id}`, updateFields);
+    return response as IDataObject;
+  }
+
+  async delete(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+    const id = this.getNodeParameter('documentId', index) as string;
+  await espoApiRequest.call(this, 'DELETE', `/Document/${id}`);
+    return { success: true, entityType: 'document', id } as IDataObject;
+  }
+
+  async getAll(this: IExecuteFunctions, index: number): Promise<IDataObject[]> {
+    const returnAll = this.getNodeParameter('returnAll', index) as boolean;
+    const qs: IDataObject = {};
+    const filterOptions = this.getNodeParameter('filterOptions', index, {}) as IDataObject;
+
+    if (filterOptions.where) {
+      if (typeof filterOptions.where === 'string') {
+        try { qs.where = JSON.parse(filterOptions.where); } catch (e: any) { throw new NodeOperationError(this.getNode(), `Invalid JSON in 'where' parameter: ${e.message}`); }
+      } else { qs.where = filterOptions.where; }
+    }
+    if (filterOptions.orderBy) qs.orderBy = filterOptions.orderBy;
+    if (filterOptions.order) qs.order = filterOptions.order;
+    if (filterOptions.select) qs.select = filterOptions.select;
+    if (filterOptions.offset) qs.offset = filterOptions.offset;
+    if (filterOptions.boolFilterList) qs.boolFilterList = filterOptions.boolFilterList;
+    if (filterOptions.primaryFilter) qs.primaryFilter = filterOptions.primaryFilter;
+
+    if (returnAll) {
+  return await espoApiRequestAllItems.call(this, 'GET', '/Document', {}, qs);
+    } else {
+      const limit = this.getNodeParameter('limit', index) as number;
+      qs.maxSize = limit;
+  const response = await espoApiRequest.call(this, 'GET', '/Document', {}, qs);
+      return response.list as IDataObject[];
+    }
+  }
+}

--- a/nodes/EspoCRM/handlers/HandlerFactory.ts
+++ b/nodes/EspoCRM/handlers/HandlerFactory.ts
@@ -7,6 +7,8 @@ import { TaskHandler } from './TaskHandler';
 import { CallHandler } from './CallHandler';
 import { OpportunityHandler } from './OpportunityHandler';
 import { CaseHandler } from './CaseHandler';
+import { AttachmentHandler } from './AttachmentHandler';
+import { DocumentHandler } from './DocumentHandler';
 import { EntityHandler } from './EntityHandler';
 
 /**
@@ -39,6 +41,10 @@ export class HandlerFactory {
         return new CaseHandler();
       case 'customEntity':
         return new CustomEntityHandler();
+      case 'attachment':
+        return new AttachmentHandler();
+      case 'document':
+        return new DocumentHandler();
       default:
         throw new Error(`Unsupported resource type: ${resource}`);
     }

--- a/nodes/EspoCRM/operations/attachment/attachment.operations.ts
+++ b/nodes/EspoCRM/operations/attachment/attachment.operations.ts
@@ -1,0 +1,88 @@
+import { INodeProperties } from 'n8n-workflow';
+
+export const attachmentOperations: INodeProperties[] = [
+  {
+    displayName: 'Operation',
+    name: 'operation',
+    type: 'options',
+    noDataExpression: true,
+    displayOptions: { show: { resource: ['attachment'] } },
+    options: [
+      { name: 'Upload', value: 'upload', description: 'Upload an attachment', action: 'Upload attachment' },
+      { name: 'Get', value: 'get', description: 'Get attachment metadata', action: 'Get attachment' },
+      { name: 'Delete', value: 'delete', description: 'Delete an attachment', action: 'Delete attachment' },
+    ],
+    default: 'upload',
+  },
+];
+
+export const attachmentFields: INodeProperties[] = [
+  // Upload
+  {
+    displayName: 'Binary Property',
+    name: 'binaryPropertyName',
+    type: 'string',
+    default: 'data',
+    description: 'Name of the binary property to upload',
+    displayOptions: { show: { resource: ['attachment'], operation: ['upload'] } },
+    required: true,
+  },
+  {
+    displayName: 'Role',
+    name: 'role',
+    type: 'options',
+    options: [
+      { name: 'Attachment', value: 'Attachment' },
+      { name: 'Inline Attachment', value: 'Inline Attachment' },
+      { name: 'Import File', value: 'Import File' },
+      { name: 'Export File', value: 'Export File' },
+      { name: 'Mail Merge', value: 'Mail Merge' },
+      { name: 'Mass Pdf', value: 'Mass Pdf' },
+    ],
+    default: 'Attachment',
+    description: 'Attachment role; must be Attachment',
+    displayOptions: { show: { resource: ['attachment'], operation: ['upload'] } },
+  },
+  {
+    displayName: 'Related Type',
+    name: 'relatedType',
+    type: 'string',
+    default: 'Document',
+    description: 'Entity type the attachment relates to (e.g., Document, Note, etc.)',
+    displayOptions: { show: { resource: ['attachment'], operation: ['upload'] } },
+  },
+  {
+    displayName: 'Field',
+    name: 'field',
+    type: 'string',
+    default: 'file',
+    description: 'Field name on the related record',
+    displayOptions: { show: { resource: ['attachment'], operation: ['upload'] } },
+  },
+  {
+    displayName: 'Additional Fields',
+    name: 'additionalFields',
+    type: 'collection',
+    default: {},
+    placeholder: 'Add Field',
+    displayOptions: { show: { resource: ['attachment'], operation: ['upload'] } },
+    options: [
+      { displayName: 'Parent Type', name: 'parentType', type: 'string', default: '' },
+      { displayName: 'Related ID', name: 'relatedId', type: 'string', default: '' },
+      { displayName: 'Parent ID', name: 'parentId', type: 'string', default: '' },
+      { displayName: 'File Name', name: 'name', type: 'string', default: '' },
+      { displayName: 'MIME Type', name: 'type', type: 'string', default: '' },
+    ],
+  },
+
+  // Common ID field for get/delete
+  {
+    displayName: 'Attachment ID',
+    name: 'attachmentId',
+    type: 'string',
+    default: '',
+    required: true,
+    description: 'ID of attachment',
+    displayOptions: { show: { resource: ['attachment'], operation: ['get', 'delete'] } },
+  },
+];

--- a/nodes/EspoCRM/operations/document/document.operations.ts
+++ b/nodes/EspoCRM/operations/document/document.operations.ts
@@ -1,0 +1,54 @@
+import { INodeProperties } from 'n8n-workflow';
+import { operations } from '../../types';
+
+export const documentOperations: INodeProperties[] = [
+  {
+    displayName: 'Operation',
+    name: 'operation',
+    type: 'options',
+    noDataExpression: true,
+    displayOptions: { show: { resource: ['document'] } },
+    options: operations,
+    default: 'create',
+  },
+];
+
+export const documentFields: INodeProperties[] = [
+  // Create Document
+  { displayName: 'Name', name: 'name', type: 'string', default: '', required: true, description: 'Document name', displayOptions: { show: { resource: ['document'], operation: ['create'] } } },
+  { displayName: 'File ID', name: 'fileId', type: 'string', default: '', required: true, description: 'Attachment ID obtained from upload', displayOptions: { show: { resource: ['document'], operation: ['create'] } } },
+  { displayName: 'Publish Date', name: 'publishDate', type: 'dateTime', default: '', description: 'Publish date (YYYY-MM-DD)', displayOptions: { show: { resource: ['document'], operation: ['create'] } } },
+  { displayName: 'Additional Fields', name: 'additionalFields', type: 'collection', default: {}, placeholder: 'Add Field', displayOptions: { show: { resource: ['document'], operation: ['create'] } }, options: [
+    { displayName: 'Folder ID', name: 'folderId', type: 'string', default: '' },
+    { displayName: 'Status', name: 'status', type: 'options', options: [ { name: 'Active', value: 'Active' }, { name: 'Draft', value: 'Draft' } ], default: 'Active' },
+    { displayName: 'Description', name: 'description', type: 'string', typeOptions: { rows: 4 }, default: '' },
+    { displayName: 'Assigned User ID', name: 'assignedUserId', type: 'string', default: '' },
+    { displayName: 'File Name', name: 'fileName', type: 'string', default: '' },
+  ] },
+
+  // Standard get/update/delete/getAll
+  { displayName: 'Document ID', name: 'documentId', type: 'string', default: '', required: true, displayOptions: { show: { resource: ['document'], operation: ['get', 'update', 'delete'] } }, description: 'ID of the document' },
+  { displayName: 'Update Fields', name: 'updateFields', type: 'collection', default: {}, placeholder: 'Add Field', displayOptions: { show: { resource: ['document'], operation: ['update'] } }, options: [
+    { displayName: 'Name', name: 'name', type: 'string', default: '' },
+    { displayName: 'File ID', name: 'fileId', type: 'string', default: '' },
+    { displayName: 'Publish Date', name: 'publishDate', type: 'dateTime', default: '' },
+    { displayName: 'Folder ID', name: 'folderId', type: 'string', default: '' },
+    { displayName: 'Status', name: 'status', type: 'options', options: [ { name: 'Active', value: 'Active' }, { name: 'Draft', value: 'Draft' } ], default: 'Active' },
+    { displayName: 'Description', name: 'description', type: 'string', typeOptions: { rows: 4 }, default: '' },
+    { displayName: 'Assigned User ID', name: 'assignedUserId', type: 'string', default: '' },
+    { displayName: 'File Name', name: 'fileName', type: 'string', default: '' },
+  ] },
+
+  { displayName: 'Return All', name: 'returnAll', type: 'boolean', default: false, displayOptions: { show: { resource: ['document'], operation: ['getAll'] } }, description: 'Whether to return all results or only up to a given limit' },
+  { displayName: 'Limit', name: 'limit', type: 'number', default: 50, typeOptions: { minValue: 1 }, displayOptions: { show: { resource: ['document'], operation: ['getAll'], returnAll: [false] } } },
+  { displayName: 'Filter Options', name: 'filterOptions', type: 'collection', default: {}, placeholder: 'Add Filter Option', displayOptions: { show: { resource: ['document'], operation: ['getAll'] } }, options: [
+    { displayName: 'Where (Filter Conditions)', name: 'where', type: 'json', default: '[]', typeOptions: { alwaysParseJson: true }, description: 'Filter conditions for the query as defined in the EspoCRM API' },
+    { displayName: 'Order By', name: 'orderBy', type: 'string', default: '', placeholder: 'createdAt', description: 'Field to sort results by' },
+    { displayName: 'Order Direction', name: 'order', type: 'options', options: [ { name: 'Ascending', value: 'asc' }, { name: 'Descending', value: 'desc' } ], default: 'desc', description: 'Direction to sort results by' },
+    { displayName: 'Select Fields', name: 'select', type: 'string', default: '', placeholder: 'id,name,fileId', description: 'Comma-separated list of fields to return' },
+    { displayName: 'Offset', name: 'offset', type: 'number', default: 0, description: 'Number of results to skip (for pagination)' },
+    { displayName: 'Skip Total Count', name: 'skipTotalCount', type: 'boolean', default: false, description: 'Skip calculating total count for large datasets to improve performance' },
+    { displayName: 'Boolean Filter List', name: 'boolFilterList', type: 'string', default: '', placeholder: 'onlyMy,followed', description: 'Comma-separated list of predefined boolean filters' },
+    { displayName: 'Primary Filter', name: 'primaryFilter', type: 'string', default: '', description: 'Context-specific base filter to apply' },
+  ] },
+];


### PR DESCRIPTION
### Attachments & Documents

You can upload files to EspoCRM as `Attachment` records and then create a `Document` that references the uploaded file. You can also download attachments to binary output in n8n.

1) Upload an Attachment

- Add an `EspoCRM` node
- Resource: `Attachment`
- Operation: `Upload`
- Fields:
  - `Binary Property`: name of the binary key on the incoming item (default `data`)
  - `Related Type`: usually `Document` (but can be any entity supported by your instance)
  - `Field`: usually `file` for Document’s File field
  - `Role`: defaults to `Attachment` (other roles: Inline Attachment)
- The node derives `name`, `type`, and `size` from the binary; you can override `name` and `type` in Additional Fields
- Output contains the created Attachment `id`

2) Create a Document linked to the uploaded file

- Add a second `EspoCRM` node
- Resource: `Document`
- Operation: `Create`
- Fields:
  - `Name`: document name
  - `File ID`: reference the Attachment `id` (from the previous step)
  - Optional: `Publish Date` (date only is expected; we normalize inputs), `Status`, `File Name`, `Folder ID`, `Description`, `Assigned User ID`

3) Download an Attachment

- Add an `EspoCRM` node
- Resource: `Attachment`
- Operation: `Download`
- Fields:
  - `Attachment ID`: the Attachment record ID
  - `Binary Property`: output key to store the file (default `data`)
- Output: one item with `binary[Binary Property]` populated, including `fileName` and `mimeType`

Notes:
- EspoCRM may restrict allowed file types by extension/MIME. If you receive `403 Not allowed file type`, verify your instance settings and the file’s extension/MIME.
- For attachment-multiple fields (e.g., `Note.attachments`), upload first, then create/update the parent entity with `attachmentsIds` including the returned attachment ID (remember to include existing IDs when updating to avoid unlinking).

