### PR TITLE
add skip duplicate check option for record creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The EspoCRM node provides comprehensive access to EspoCRM's API functionality:
   - Pagination support
   - Selective field loading
   - Skip total count for large datasets
-  - Duplicate checking control
+  - Skip duplicate verification checks on record creation (using `X-Skip-Duplicate-Check` header)
 
 - **AI Agent Tooling**
   - Dedicated `EspoCRM Tool` node that outputs an AI Tool connection for n8n Agents
@@ -99,7 +99,8 @@ Create a new contact record with customized field values:
    - Last Name
    - Email Address
 5. Add any additional fields as needed
-6. Connect to other nodes in your workflow
+6. (Optional) Under **Options**, enable **Skip Duplicate Check** if you wish to bypass EspoCRM's duplicate verification rules
+7. Connect to other nodes in your workflow
 
 ### Creating a Meeting
 

--- a/nodes/EspoCRM/EspoCRM.node.ts
+++ b/nodes/EspoCRM/EspoCRM.node.ts
@@ -365,6 +365,30 @@ export class EspoCRM implements INodeType {
 					},
 				],
 			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				placeholder: 'Add Option',
+				default: {},
+				displayOptions: {
+					show: {
+						operation: ['create'],
+					},
+					hide: {
+						resource: ['attachment', 'dynamicFields'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Skip Duplicate Check',
+						name: 'skipDuplicateCheck',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to skip duplicate verification checks during record creation',
+					},
+				],
+			},
 		],
 	};
 
@@ -469,7 +493,22 @@ export class EspoCRM implements INodeType {
 
 						// Execute API request
 						const endpoint = `/${entityType}`;
-						const responseData = await espoApiRequest.call(this, 'POST', endpoint, dataToSend);
+						const headers: IDataObject = {};
+						try {
+							const options = this.getNodeParameter('options', i, {}) as IDataObject;
+							if (options.skipDuplicateCheck === true) {
+								headers['X-Skip-Duplicate-Check'] = 'true';
+							}
+						} catch (error) {}
+						const responseData = await espoApiRequest.call(
+							this,
+							'POST',
+							endpoint,
+							dataToSend,
+							{},
+							undefined,
+							headers,
+						);
 						returnData.push(responseData as IDataObject);
 					}
 					else if (operation === 'get') {

--- a/nodes/EspoCRM/handlers/AccountHandler.ts
+++ b/nodes/EspoCRM/handlers/AccountHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { processAddressFields } from './Utils';
+import { processAddressFields, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Account entity operations
@@ -35,7 +35,8 @@ export class AccountHandler implements EntityHandler {
     
     // Execute API request
     const endpoint = '/account';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/CallHandler.ts
+++ b/nodes/EspoCRM/handlers/CallHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { toEspoDate, toEspoDateTime } from './Utils';
+import { toEspoDate, toEspoDateTime, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Call entity operations
@@ -29,7 +29,8 @@ export class CallHandler implements EntityHandler {
     }
 
     const endpoint = '/call';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/CaseHandler.ts
+++ b/nodes/EspoCRM/handlers/CaseHandler.ts
@@ -1,6 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
+import { getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Case entity operations
@@ -14,7 +15,8 @@ export class CaseHandler implements EntityHandler {
     Object.assign(entityData, additionalFields);
 
     const endpoint = '/case';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/ContactHandler.ts
+++ b/nodes/EspoCRM/handlers/ContactHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { processAddressFields } from './Utils';
+import { processAddressFields, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Contact entity operations
@@ -29,7 +29,8 @@ export class ContactHandler implements EntityHandler {
 
     // Execute API request
     const endpoint = '/contact';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/CustomEntityHandler.ts
+++ b/nodes/EspoCRM/handlers/CustomEntityHandler.ts
@@ -1,6 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
+import { getCreateHeaders } from './Utils';
 
 /**
  * Class for handling custom entity operations
@@ -15,7 +16,8 @@ export class CustomEntityHandler implements EntityHandler {
 
     // Execute API request
     const endpoint = `/${entityType}`;
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/DocumentHandler.ts
+++ b/nodes/EspoCRM/handlers/DocumentHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { toEspoDate } from './Utils';
+import { toEspoDate, getCreateHeaders } from './Utils';
 
 export class DocumentHandler implements EntityHandler {
   async create(this: IExecuteFunctions, index: number): Promise<IDataObject> {
@@ -14,7 +14,8 @@ export class DocumentHandler implements EntityHandler {
     const additionalFields = this.getNodeParameter('additionalFields', index, {}) as IDataObject;
     Object.assign(entityData, additionalFields);
 
-  const response = await espoApiRequest.call(this, 'POST', '/Document', entityData);
+    const headers = getCreateHeaders(this, index);
+    const response = await espoApiRequest.call(this, 'POST', '/Document', entityData, {}, undefined, headers);
     return response as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/LeadHandler.ts
+++ b/nodes/EspoCRM/handlers/LeadHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { processAddressFields } from './Utils';
+import { processAddressFields, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Lead entity operations
@@ -30,7 +30,8 @@ export class LeadHandler implements EntityHandler {
 
     // Execute API request
     const endpoint = '/lead';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/MeetingHandler.ts
+++ b/nodes/EspoCRM/handlers/MeetingHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { toEspoDate, toEspoDateTime } from './Utils';
+import { toEspoDate, toEspoDateTime, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Meeting entity operations
@@ -32,7 +32,8 @@ export class MeetingHandler implements EntityHandler {
     }
 
     const endpoint = '/meeting';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/OpportunityHandler.ts
+++ b/nodes/EspoCRM/handlers/OpportunityHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { toEspoDate } from './Utils';
+import { toEspoDate, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Opportunity entity operations
@@ -17,7 +17,8 @@ export class OpportunityHandler implements EntityHandler {
     Object.assign(entityData, additionalFields);
 
     const endpoint = '/opportunity';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/TaskHandler.ts
+++ b/nodes/EspoCRM/handlers/TaskHandler.ts
@@ -1,7 +1,7 @@
 import { IExecuteFunctions, IDataObject, NodeOperationError } from 'n8n-workflow';
 import { EntityHandler } from './EntityHandler';
 import { espoApiRequest, espoApiRequestAllItems } from '../GenericFunctions';
-import { toEspoDate, toEspoDateTime } from './Utils';
+import { toEspoDate, toEspoDateTime, getCreateHeaders } from './Utils';
 
 /**
  * Class for handling Task entity operations
@@ -28,7 +28,8 @@ export class TaskHandler implements EntityHandler {
     }
 
     const endpoint = '/task';
-    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData);
+    const headers = getCreateHeaders(this, index);
+    const responseData = await espoApiRequest.call(this, 'POST', endpoint, entityData, {}, undefined, headers);
     return responseData as IDataObject;
   }
 

--- a/nodes/EspoCRM/handlers/Utils.ts
+++ b/nodes/EspoCRM/handlers/Utils.ts
@@ -1,4 +1,4 @@
-import { IDataObject } from 'n8n-workflow';
+import { IDataObject, IExecuteFunctions } from 'n8n-workflow';
 
 /**
  * Process address fields for entities
@@ -85,4 +85,20 @@ export function toEspoDate(value?: string): string | undefined {
     const mm = pad(d.getMonth() + 1);
     const dd = pad(d.getDate());
     return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Get headers for create operation, including skip duplicate check if requested
+ */
+export function getCreateHeaders(ctx: IExecuteFunctions, index: number): IDataObject {
+  const headers: IDataObject = {};
+  try {
+    const options = ctx.getNodeParameter('options', index, {}) as IDataObject;
+    if (options.skipDuplicateCheck === true) {
+      headers['X-Skip-Duplicate-Check'] = 'true';
+    }
+  } catch (error) {
+    // options parameter might not be defined in all contexts
+  }
+  return headers;
 }


### PR DESCRIPTION
Adds support for the 'X-Skip-Duplicate-Check: true' header during entity creation, addressing issue #17 on GitHub.